### PR TITLE
Initial proposal for being more CSP-friendly

### DIFF
--- a/require.js
+++ b/require.js
@@ -185,10 +185,16 @@ var requirejs, require, define;
     }
 
     //Allow for a require config object
+    //If the global variable is not set, try to read it from a known location to be more CSP-friendly?
+    if (typeof require === 'undefined') {
+      var node = document.getElementById('require-config-data');
+      require = JSON.parse(node.innerHTML);
+    }
+
     if (typeof require !== 'undefined' && !isFunction(require)) {
-        //assume it is a config object.
-        cfg = require;
-        require = undefined;
+      //assume it is a config object.
+      cfg = require;
+      require = undefined;
     }
 
     function newContext(contextName) {


### PR DESCRIPTION
This came out of some work I was doing with the requirejs-rails gem, but I hope this is more useful outside of the rails-related gem. This would give us the option to read the config value from the DOM. The requirejs-rails technique inserts a snippet of javascript with ```var require = some json object``` where this is unnecessary. Surely any application can read and set this variable themselves, but this would hopefully streamline the process.

I will gladly write tests if this is a patch you would be willing to accept.