### PR TITLE
require.toUrl fix for multiple relative segments

### DIFF
--- a/require.js
+++ b/require.js
@@ -1441,19 +1441,23 @@ var requirejs, require, define;
                      */
                     toUrl: function (moduleNamePlusExt) {
                         var ext,
-                            index = moduleNamePlusExt.lastIndexOf('.'),
-                            segment = moduleNamePlusExt.split('/')[0],
+                            segments = moduleNamePlusExt.split('/'),
+                            segment = segments[0],
+                            lastSegment = segments[segments.length - 1],
+                            extIndex = lastSegment === '.' || lastSegment === '..' ? -1 : lastSegment.lastIndexOf('.'),
                             isRelative = segment === '.' || segment === '..';
 
                         //Have a file extension alias, and it is not the
                         //dots from a relative path.
-                        if (index !== -1 && (!isRelative || index > 1)) {
-                            ext = moduleNamePlusExt.substring(index, moduleNamePlusExt.length);
-                            moduleNamePlusExt = moduleNamePlusExt.substring(0, index);
+                        if (extIndex !== -1) {
+                            // make the extIndex relative to the whole path
+                            extIndex = moduleNamePlusExt.length - (lastSegment.length - extIndex);
+                            ext = moduleNamePlusExt.substring(extIndex, moduleNamePlusExt.length);
+                            moduleNamePlusExt = moduleNamePlusExt.substring(0, extIndex);
                         }
 
                         return context.nameToUrl(normalize(moduleNamePlusExt,
-                                                relMap && relMap.id, true), ext,  true);
+                                                relMap && relMap.id, true), ext, true);
                     },
 
                     defined: function (id) {

--- a/require.js
+++ b/require.js
@@ -442,7 +442,7 @@ var requirejs, require, define;
                         //Plugin is loaded, use its normalize method.
                         normalizedName = pluginModule.normalize(name, function (name) {
                             return normalize(name, parentName, applyMap);
-                        }, parentName);
+                        });
                     } else {
                         // If nested plugin references, then do not try to
                         // normalize, as it will not normalize correctly. This
@@ -955,7 +955,7 @@ var requirejs, require, define;
                         if (plugin.normalize) {
                             name = plugin.normalize(name, function (name) {
                                 return normalize(name, parentName, true);
-                            }, parentName) || '';
+                            }) || '';
                         }
 
                         //prefix and name should already be normalized, no need

--- a/require.js
+++ b/require.js
@@ -449,7 +449,7 @@ var requirejs, require, define;
                         //Plugin is loaded, use its normalize method.
                         normalizedName = pluginModule.normalize(name, function (name) {
                             return normalize(name, parentName, applyMap);
-                        });
+                        }, parentName);
                     } else {
                         normalizedName = normalize(name, parentName, applyMap);
                     }
@@ -953,7 +953,7 @@ var requirejs, require, define;
                         if (plugin.normalize) {
                             name = plugin.normalize(name, function (name) {
                                 return normalize(name, parentName, true);
-                            }) || '';
+                            }, parentName) || '';
                         }
 
                         //prefix and name should already be normalized, no need


### PR DESCRIPTION
require.toUrl would return the wrong result when passed something like '../../module' because it assumes the last period character is an extension separator in a relative path so long as its index is > 1.  This is a possible fix for this case although there may be a more elegant one.