### PR TITLE
fix "TypeError: g is undefined"

### DIFF
--- a/require.js
+++ b/require.js
@@ -149,7 +149,9 @@ var requirejs, require, define;
         }
         var g = global;
         each(value.split('.'), function (part) {
-            g = g[part];
+            if (typeof g !== 'undefined') {
+                g = g[part];
+            }
         });
         return g;
     }


### PR DESCRIPTION
The following example produces an undefined-error, note the dot in the shim named `foo.bar.js`.

```javascript
require.config({
	paths: {
		'foo.bar': 'js/foo.bar'
	},
	shim: {
		'foo.bar': { exports: 'foo.bar' }
	}
});
```

and then we get the error on loading `'foo.bar'`:
```javascript
require(['foo.bar'], function(){ /* ... */ });
```

The shim is loaded but the callback doesn't fire. This patch fixes it.