### PR TITLE
Add contextName to localRequire

### DIFF
--- a/require.js
+++ b/require.js
@@ -1441,6 +1441,8 @@ var requirejs, require, define;
                 mixin(localRequire, {
                     isBrowser: isBrowser,
 
+                    contextName: this.contextName,
+
                     /**
                      * Converts a module name + .extension into an URL path.
                      * *Requires* the use of a module name. It does not support using


### PR DESCRIPTION
Hello ;) 

Sometimes we need to know which require context is requiring module. Some configuration could change from different context.

If there another way to do that already, fortunately I am aware with it. 

Thx a lot.