### PR TITLE
Fix loading custom-context bundle created by r.js for IE10 and lower

### DIFF
--- a/require.js
+++ b/require.js
@@ -2001,10 +2001,11 @@ var requirejs, require, define;
      * name.
      */
     define = function (name, deps, callback) {
-        var node, context;
+        var node, context,
+            isAnonymousMod = (typeof name !== 'string');
 
         //Allow for anonymous modules
-        if (typeof name !== 'string') {
+        if (isAnonymousMod) {
             //Adjust args appropriately
             callback = deps;
             deps = name;
@@ -2043,7 +2044,7 @@ var requirejs, require, define;
 
         //If in IE 6-8 and hit an anonymous define() call, do the interactive
         //work.
-        if (useInteractive) {
+        if (isAnonymousMod && useInteractive) {
             node = currentlyAddingScript || getInteractiveScript();
             if (node) {
                 if (!name) {


### PR DESCRIPTION
When I use `require()` to load a **custom-context** and **custom-baseUrl** bundle(as example below that created by r.js)  asynchronously in IE10 and lower. All dependencies inside bundle are loaded in `interactive` way that will cause error as a result of incorrect baseUrl. The root cause is that these modules are pushed into queue of default context `_`, not global queue.

Stop using interactive mode only for named module to avoid this problem.

```
define('foo',[], function () {
    // ...
});

define('foo/bar',[], function () {
    // ...
});

(function () {
    // create a custom context
    var myRequire = requirejs.config({
        baseUrl: '/test/js/',
        context: 'my-context',
        paths: {
            // ...
        }
    });

    myRequire([ './foo', './foo/bar' ], function (foo, bar) {
        // ...
    });
}());

```