### PR TITLE
fixfox cann't resolve the '\'

### DIFF
--- a/require.js
+++ b/require.js
@@ -1989,6 +1989,8 @@ var requirejs, require, define;
                     mainScript = dataMain;
                 }
 
+                dataMain = dataMain.replace( "\\", "/" );
+
                 //Put the data-main script in the files to load.
                 cfg.deps = cfg.deps ? cfg.deps.concat(mainScript) : [mainScript];
 


### PR DESCRIPTION
on initialization the main script load without path config, will got an error of 404

eg:
<script src="/lib/vendor.js" data-main="views\index.js"></script>