### PR TITLE
Fix 'config as the first option' example

### DIFF
--- a/docs/api.html
+++ b/docs/api.html
@@ -538,15 +538,13 @@ module loading that may use that module. See the <a href="#errbacks">errback sec
 
 <pre><code>&lt;script src="scripts/require.js"&gt;&lt;/script&gt;
 &lt;script&gt;
-  require.config({
+  requirejs({
     baseUrl: "/another/path",
     paths: {
         "some": "some/v1.0"
     },
     waitSeconds: 15
-  });
-  require( ["some/module", "my/module", "a.js", "b.js"],
-    function(someModule,    myModule) {
+  }, ["some/module", "my/module", "a.js", "b.js"], function(someModule,    myModule) {
         //This function will be called when all the dependencies
         //listed above are loaded. Note that this function could
         //be called before the page is loaded.


### PR DESCRIPTION
Change
```
require.config(config_options);
require(deps, function);
```
to
```
requirejs(config_options, deps, function);
```