### PR TITLE
Declare charset in tests/index.html

### DIFF
--- a/tests/index.html
+++ b/tests/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta charset="utf-8">
     <title>require.js: Tests</title>
 </head>
 <body>


### PR DESCRIPTION
Fixes this warning in the JS console in FF 37:

  > The character encoding of the HTML document was not declared.
  The document will render with garbled text in some browser
  configurations if the document contains characters from outside
  the US-ASCII range. The character encoding of the page must be
  declared in the document or in the transfer protocol.