### PR TITLE
Suppress error "Mismatched anonymous define()"

### DIFF
--- a/require.js
+++ b/require.js
@@ -1547,7 +1547,7 @@ var requirejs, require, define;
 
                 while (defQueue.length) {
                     args = defQueue.shift();
-                    if (args[0] == null) {
+                    if (args[0] === null || args[0] === void 0) {
                         args[0] = moduleName;
                         //If already found an anonymous module and bound it
                         //to this name, then this is some other anon module

--- a/require.js
+++ b/require.js
@@ -1235,10 +1235,10 @@ var requirejs, require, define;
             //Make sure any remaining defQueue items get properly processed.
             while (defQueue.length) {
                 args = defQueue.shift();
-                if (args[0] === null) {
+                if (args[0] === void 0) {
                     return onError(makeError('mismatch', 'Mismatched anonymous define() module: ' +
                         args[args.length - 1]));
-                } else {
+                } else if (args[0] !== null) {
                     //args are id, deps, factory. Should be normalized by the
                     //define() function.
                     callGetModule(args);
@@ -1547,7 +1547,7 @@ var requirejs, require, define;
 
                 while (defQueue.length) {
                     args = defQueue.shift();
-                    if (args[0] === null) {
+                    if (args[0] == null) {
                         args[0] = moduleName;
                         //If already found an anonymous module and bound it
                         //to this name, then this is some other anon module
@@ -2009,11 +2009,11 @@ var requirejs, require, define;
         var node, context;
 
         //Allow for anonymous modules
-        if (typeof name !== 'string') {
+        if (typeof name !== 'string' && name !== null) {
             //Adjust args appropriately
             callback = deps;
             deps = name;
-            name = null;
+            name = void 0;
         }
 
         //This module may not have dependencies


### PR DESCRIPTION
This fix allows you to suppress error "Mismatched anonymous define ()"

It is often necessary to determine the independent modules, for example such as "jQuery". What would be a possibility to declare the module without tying it tightly to a single name.

it is not flexible:
```js
define('jquery', [], function () {});
```
It is also as above, but more flexibly:
```js
define(null, [], function () {});
```

For example, if you create a library:

mylib.js:
```js
(function(factory) {
  if (typeof define === 'function' && define.amd) {
    // null - it is also an anonymous module, except that in determining the
    // module out of context requirejs, an error will be suppressed.
    define(null, [], factory());
  } else {
    factory();
  }
})(function() {
  // library code here
  return window.exportObject = exportObject;
});
```