### PR TITLE
Ensure global setTimeout reference is captured in require.js

### DIFF
--- a/require.js
+++ b/require.js
@@ -6,7 +6,7 @@
 //Not using strict: uneven strict support in browsers, #392, and causes
 //problems with requirejs.exec()/transpiler plugins that may not be strict.
 /*jslint regexp: true, nomen: true, sloppy: true */
-/*global window, navigator, document, importScripts, setTimeout, opera */
+/*global window, navigator, document, importScripts, opera */
 
 var requirejs, require, define;
 (function (global) {
@@ -36,7 +36,8 @@ var requirejs, require, define;
         contexts = {},
         cfg = {},
         globalDefQueue = [],
-        useInteractive = false;
+        useInteractive = false,
+        setTimeout = global.setTimeout;
 
     function isFunction(it) {
         return ostring.call(it) === '[object Function]';

--- a/tests/all.js
+++ b/tests/all.js
@@ -7,6 +7,8 @@ var hasToString = (function () {
 
 doh.registerUrl("simple", "../simple.html");
 
+doh.registerUrl("setTimeout", "../setTimeout.html");
+
 //PS3 does not like this test
 doh.registerUrl("baseUrl", "../baseUrl.html");
 

--- a/tests/setTimeout-tests.js
+++ b/tests/setTimeout-tests.js
@@ -10,11 +10,7 @@
     	return localSetTimeout.call(global, fn, delay);
     };
 
-    require({
-        baseUrl: "./"
-        },
-        ["simple"],
-        function(simple) {
+    require({ baseUrl: "./" }, ["simple"], function(simple) {
         doh.register(
             "setTimeout",
             [
@@ -25,6 +21,5 @@
         );
 
         doh.run();
-        }
-    );
+    });
 })(this);

--- a/tests/setTimeout-tests.js
+++ b/tests/setTimeout-tests.js
@@ -1,0 +1,30 @@
+(function (global) {
+    // Store local setTimeout reference for monkey-patching DOH
+    var localSetTimeout = global.setTimeout;
+
+    // Clobber setTimeout to ensure that the below require() still works...
+    global.setTimeout = null;
+
+    // ...but ensure doh.setTimeout does not get broken
+    doh.setTimeout = function (fn, delay) {
+    	return localSetTimeout.call(global, fn, delay);
+    };
+
+    require({
+        baseUrl: "./"
+        },
+        ["simple"],
+        function(simple) {
+        doh.register(
+            "setTimeout",
+            [
+                function checkSetTimeout(t){
+                    t.is("blue", simple.color);
+                }
+            ]
+        );
+
+        doh.run();
+        }
+    );
+})(this);

--- a/tests/setTimeout.html
+++ b/tests/setTimeout.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>require.js: Simple Test</title>
+    <script type="text/javascript" src="../require.js"></script>
+    <script type="text/javascript" src="doh/runner.js"></script>
+    <script type="text/javascript" src="doh/_browserRunner.js"></script>
+    <script>moreSimpleTests = true</script>
+    <script type="text/javascript" src="setTimeout-tests.js"></script>
+</head>
+<body>
+    <h1>require.js: setTimeout Test</h1>
+    <p>Check console for messages</p>
+</body>
+</html>

--- a/tests/setTimeout.html
+++ b/tests/setTimeout.html
@@ -5,7 +5,6 @@
     <script type="text/javascript" src="../require.js"></script>
     <script type="text/javascript" src="doh/runner.js"></script>
     <script type="text/javascript" src="doh/_browserRunner.js"></script>
-    <script>moreSimpleTests = true</script>
     <script type="text/javascript" src="setTimeout-tests.js"></script>
 </head>
 <body>

--- a/tests/setTimeout.html
+++ b/tests/setTimeout.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>require.js: Simple Test</title>
+    <title>require.js: setTimeout Test</title>
     <script type="text/javascript" src="../require.js"></script>
     <script type="text/javascript" src="doh/runner.js"></script>
     <script type="text/javascript" src="doh/_browserRunner.js"></script>


### PR DESCRIPTION
Ensuring global setTimeout reference is captured in require.js so that clobbering `setTimeout` does not break everything.

This is useful/necessary when using RequireJS with a unit test framework that simulates `setTimeout` (for example [sinon.js][1]). Since RequireJS relies on the default behavior of setTimeout and is a library which ideally should function the same way even when other frameworks are involved, it seems worthwhile to close over the default `setTimeout` function.

I've also added a unit test file to capture this-- please let me know if that can be improved.

  [1]: http://sinonjs.org/