### PR TITLE
Add name property to package.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "requirejs",
   "volo": {
     "url": "https://raw.github.com/jrburke/requirejs/{version}/require.js"
   },


### PR DESCRIPTION
Our deployment tooling requires a name property in package.js. This patch adds one.